### PR TITLE
Document EcoSIM provenance and make just find search it

### DIFF
--- a/.claude/skills/bervo-terms/SKILL.md
+++ b/.claude/skills/bervo-terms/SKILL.md
@@ -91,9 +91,11 @@ BERVO began as a catalogue of EcoSIM model parameters, and that origin is still 
 biggest thing about the term set: **1,749 of 2,352 terms (74%) carry an
 `EcoSIM Variable Name` and a `File Name`** naming the EcoSIM source file they came from.
 
-These two columns are provenance, not semantics — `EcoSIM Variable Name` emits
-`oio:hasRelatedSynonym` and `File Name` emits `rdfs:comment`, not axioms — but they are the most useful handle you have when a
-term request comes from someone working with the model.
+These two columns are provenance, not logical content — `EcoSIM Variable Name` emits
+`oio:hasRelatedSynonym` and `File Name` emits `rdfs:comment`, so neither produces an
+axiom. Note that the synonym does put the EcoSIM code identifier into the released
+ontology, where lexical matchers and search will find it. They are the most useful
+handle you have when a term request comes from someone working with the model.
 
 ### Finding a term from the model side
 
@@ -112,10 +114,16 @@ have guessed from the code identifier.
 ### The source file usually tells you the category
 
 There are 33 distinct EcoSIM source files, and **32 of them map to one dominant BERVO
-`Category`**. This is the strongest placement heuristic available. Dominant-category shares
-range from 60% to 100%; the seven largest files are shown, and they are also among the
-strongest — the weaker tail (`NitroPars.txt` and `FlagDataType.txt` at 60%,
-`ChemTracerParsMod.txt` 62%, `AqueChemDatatype.txt` 66%) still needs a judgement call:
+`Category`**. This is the strongest placement heuristic available.
+
+Shares run from 60% to 100% across those 32, with one outlier at 19% (see below). The
+seven files below are simply the **largest by term count**; their shares are typical
+rather than exceptional — the median across all 33 files is 90%, and so is the mean of
+these seven. A file's absence from this table says nothing about how strong its prior
+is: `SoilPhysDataType.txt` (100%), `MicrobialDataType.txt` (98%) and `SOMDataType.txt`
+(97%) are all stronger than most of what is shown. The weaker end — `NitroPars.txt` and
+`FlagDataType.txt` at 60%, `ChemTracerParsMod.txt` 62%, `AqueChemDatatype.txt` 66% —
+needs a judgement call. Check your own file rather than reading across from these:
 
 | `File Name` | Dominant `Category` | Share |
 | --- | --- | --- |
@@ -148,7 +156,7 @@ so confirm against the definition rather than assuming:
 | Suffix | Count | Reading |
 | --- | --- | --- |
 | `_col` | 361 | Column-level, i.e. aggregated over the whole ecosystem column |
-| `_vr` | 304 | Vertically resolved, i.e. per soil layer (only ~19% of labels or definitions say so explicitly — confirm before relying on it) |
+| `_vr` | 304 | Vertically resolved, i.e. per soil layer. Only ~19% say so explicitly — confirm |
 | `_pft` | 263 | Per plant functional type |
 | `_brch` | 70 | Per branch (64% of definitions mention a branch) |
 | `_2D`, `_2DH` | 43 | Two-dimensional / horizontal |

--- a/.claude/skills/bervo-terms/SKILL.md
+++ b/.claude/skills/bervo-terms/SKILL.md
@@ -85,6 +85,78 @@ There is a known backlog of unresolvable-label warnings in `qualifiers`,
 unrelated task — they need curator judgement about whether the target term should
 exist. Fix only the ones your change touches.
 
+## EcoSIM provenance
+
+BERVO began as a catalogue of EcoSIM model parameters, and that origin is still the single
+biggest thing about the term set: **1,749 of 2,352 terms (74%) carry an
+`EcoSIM Variable Name` and a `File Name`** naming the EcoSIM source file they came from.
+
+These two columns are provenance, not semantics — they emit `rdfs:comment` and
+`oio:hasRelatedSynonym`, not axioms — but they are the most useful handle you have when a
+term request comes from someone working with the model.
+
+### Finding a term from the model side
+
+`just find` searches the EcoSIM variable name as well as labels and definitions, so a
+request phrased in model terms resolves directly:
+
+```bash
+just find "Eco_NetRad_col"       # by EcoSIM variable name
+just find "CanopyDataType"       # everything from one EcoSIM source file
+```
+
+Always try this before creating a term for an EcoSIM parameter. A variable that exists in
+the model very often already exists in BERVO under a human-readable label you would not
+have guessed from the code identifier.
+
+### The source file usually tells you the category
+
+There are 33 distinct EcoSIM source files, and **32 of them map to one dominant BERVO
+`Category`**. This is the strongest placement heuristic available:
+
+| `File Name` | Dominant `Category` | Share |
+| --- | --- | --- |
+| `SoluteParMod.txt` | Constants for specific chemical reactions | 100% |
+| `SoilBGCDataType.txt` | Soil biogeochemistry variable | 98% |
+| `SoilWaterDataType.txt` | Soil and water variable | 96% |
+| `CanopyDataType.txt` | Canopy variable | 90% |
+| `ClimForcDataType.txt` | Climate force variable | 83% |
+| `PlantDataRateType.txt` | Plant rate variable | 81% |
+| `PlantTraitDataType.txt` | Plant trait variable | 79% |
+
+When adding a term from a known EcoSIM file, check what its file's neighbours use:
+
+```bash
+just find "SoilBGCDataType.txt"
+```
+
+Treat this as a strong prior, not a rule — the minority cases are real, and the category
+should still be the most specific correct parent.
+
+### Naming conventions in EcoSIM variable names
+
+Suffixes mark the dimension a variable is resolved over. These are observed conventions,
+so confirm against the definition rather than assuming:
+
+| Suffix | Count | Reading |
+| --- | --- | --- |
+| `_col` | 361 | Column-level, i.e. aggregated over the whole ecosystem column |
+| `_vr` | 304 | Vertically resolved — labels often say so outright |
+| `_pft` | 263 | Per plant functional type |
+| `_brch` | 70 | Per branch (64% of definitions mention a branch) |
+| `_2D`, `_2DH` | 43 | Two-dimensional / horizontal |
+
+Prefixes group tracers and chemistry: `trcg_`, `trcs_`, `trcn_`, `trcSalt_`, `TRChem_`,
+`DOM_`, and `Eco_`/`ECO_` for ecosystem-level quantities.
+
+A term whose EcoSIM name differs only by suffix from an existing term is usually a genuinely
+distinct variable (a column aggregate and its vertically resolved counterpart are different
+things) — but say so explicitly in the definition, or the two become impossible to tell
+apart.
+
+> `EcoSIM Other Names` is populated on **zero** rows. Leave it alone rather than inventing a
+> use for it.
+
 ## Cross-references to other ontologies
 
 The `DbXrefs` column maps a BERVO term to an equivalent term elsewhere. There are 351

--- a/.claude/skills/bervo-terms/SKILL.md
+++ b/.claude/skills/bervo-terms/SKILL.md
@@ -91,8 +91,8 @@ BERVO began as a catalogue of EcoSIM model parameters, and that origin is still 
 biggest thing about the term set: **1,749 of 2,352 terms (74%) carry an
 `EcoSIM Variable Name` and a `File Name`** naming the EcoSIM source file they came from.
 
-These two columns are provenance, not semantics — they emit `rdfs:comment` and
-`oio:hasRelatedSynonym`, not axioms — but they are the most useful handle you have when a
+These two columns are provenance, not semantics — `EcoSIM Variable Name` emits
+`oio:hasRelatedSynonym` and `File Name` emits `rdfs:comment`, not axioms — but they are the most useful handle you have when a
 term request comes from someone working with the model.
 
 ### Finding a term from the model side
@@ -112,7 +112,10 @@ have guessed from the code identifier.
 ### The source file usually tells you the category
 
 There are 33 distinct EcoSIM source files, and **32 of them map to one dominant BERVO
-`Category`**. This is the strongest placement heuristic available:
+`Category`**. This is the strongest placement heuristic available. Dominant-category shares
+range from 60% to 100%; the seven largest files are shown, and they are also among the
+strongest — the weaker tail (`NitroPars.txt` and `FlagDataType.txt` at 60%,
+`ChemTracerParsMod.txt` 62%, `AqueChemDatatype.txt` 66%) still needs a judgement call:
 
 | `File Name` | Dominant `Category` | Share |
 | --- | --- | --- |
@@ -130,6 +133,10 @@ When adding a term from a known EcoSIM file, check what its file's neighbours us
 just find "SoilBGCDataType.txt"
 ```
 
+**The one exception is `EcoSimSumDataType.txt`**: its 32 terms spread across 10 categories
+with a top share of 19%, because it is a summary/aggregation file with no natural home. The
+heuristic tells you nothing there.
+
 Treat this as a strong prior, not a rule — the minority cases are real, and the category
 should still be the most specific correct parent.
 
@@ -141,7 +148,7 @@ so confirm against the definition rather than assuming:
 | Suffix | Count | Reading |
 | --- | --- | --- |
 | `_col` | 361 | Column-level, i.e. aggregated over the whole ecosystem column |
-| `_vr` | 304 | Vertically resolved — labels often say so outright |
+| `_vr` | 304 | Vertically resolved, i.e. per soil layer (only ~19% of labels or definitions say so explicitly — confirm before relying on it) |
 | `_pft` | 263 | Per plant functional type |
 | `_brch` | 70 | Per branch (64% of definitions mention a branch) |
 | `_2D`, `_2DH` | 43 | Two-dimensional / horizontal |

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -84,6 +84,18 @@ jobs:
       # back to the OAuth token rather than shadowing it, and an unusable
       # credential fails here in seconds instead of as an opaque is_error:true
       # three minutes into the agent run.
+      # Posting identity. With the App secrets set, comments and git operations
+      # come from the app (e.g. "ai4c-agent") instead of the generic
+      # "github-actions[bot]". continue-on-error means the step is a no-op when
+      # the secrets are absent, and the workflow falls back to github.token.
+      - name: Generate agent app token
+        id: agent-token
+        continue-on-error: true
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.AI4C_AGENT_APP_ID }}
+          private-key: ${{ secrets.AI4C_AGENT_PRIVATE_KEY }}
+
       - name: Resolve Claude auth
         if: env.HAS_CLAUDE_AUTH == 'true'
         uses: ./.github/actions/resolve-claude-auth
@@ -98,7 +110,7 @@ jobs:
         with:
           anthropic_api_key: ${{ env.AUTH_MODE == 'api_key' && secrets.ANTHROPIC_API_KEY || '' }}
           claude_code_oauth_token: ${{ env.AUTH_MODE == 'oauth' && secrets.CLAUDE_CODE_OAUTH_TOKEN || '' }}
-          github_token: ${{ github.token }}
+          github_token: ${{ steps.agent-token.outputs.token || github.token }}
           # `track_progress` is what makes the action actually run on a
           # pull_request event -- without it the step succeeds in seconds having
           # done nothing. It also gives one updating comment instead of many.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -9,13 +9,24 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize]
+    # Ontology content, the tooling that validates it, and the instructions that
+    # govern how agents edit it. The instruction files matter as much as the
+    # content: a bad edit to AGENTS.md or a skill propagates into every later
+    # agent run, so they must not be exempt from review.
     paths:
       - 'src/ontology/bervo-src.csv'
       - 'src/ontology/bervo-edit.owl'
       - 'src/ontology/bervo-annotations.ttl'
       - 'src/ontology/bervo-odk.yaml'
+      - 'src/ontology/bervo.Makefile'
       - 'src/sparql/**'
       - 'src/scripts/**'
+      - 'tests/**'
+      - 'AGENTS.md'
+      - '.claude/**'
+      - 'justfile'
+      - '.github/workflows/**'
+      - '.github/actions/**'
   workflow_dispatch:
     inputs:
       model:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -120,8 +120,16 @@ jobs:
             ${{ steps.validate.outputs.report }}
             ```
 
-            Do not repeat what the validator already reported. Focus on what it
-            cannot check:
+            If this PR changes only tooling, tests, workflows, or instruction
+            files (AGENTS.md, .claude/**, justfile) and adds no terms, the
+            term-level checklist below mostly does not apply. Check instead that
+            every documented fact still holds against bervo-src.csv, that every
+            documented command actually runs, and that guidance an agent will
+            follow is accurate — a wrong number in .claude/** propagates into
+            every later agent run.
+
+            Otherwise, do not repeat what the validator already reported. Focus
+            on what it cannot check:
 
             - Is any added term a duplicate or near-duplicate of an existing one?
               Check with `just find` on the label and each synonym. This is the most

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -44,6 +44,18 @@ jobs:
       - name: Install just
         run: curl -fsSL https://just.systems/install.sh | bash -s -- --to /usr/local/bin
 
+      # Posting identity. With the App secrets set, comments and git operations
+      # come from the app (e.g. "ai4c-agent") instead of the generic
+      # "github-actions[bot]". continue-on-error means the step is a no-op when
+      # the secrets are absent, and the workflow falls back to github.token.
+      - name: Generate agent app token
+        id: agent-token
+        continue-on-error: true
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.AI4C_AGENT_APP_ID }}
+          private-key: ${{ secrets.AI4C_AGENT_PRIVATE_KEY }}
+
       - name: Resolve Claude auth
         if: env.HAS_CLAUDE_AUTH == 'true'
         uses: ./.github/actions/resolve-claude-auth
@@ -58,7 +70,7 @@ jobs:
         with:
           anthropic_api_key: ${{ env.AUTH_MODE == 'api_key' && secrets.ANTHROPIC_API_KEY || '' }}
           claude_code_oauth_token: ${{ env.AUTH_MODE == 'oauth' && secrets.CLAUDE_CODE_OAUTH_TOKEN || '' }}
-          github_token: ${{ github.token }}
+          github_token: ${{ steps.agent-token.outputs.token || github.token }}
           # The action has no `model:` input; it must go through claude_args.
           claude_args: |
             --model ${{ env.AGENT_MODEL }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -75,6 +75,18 @@ jobs:
           python -m pip install --upgrade pip pytest
           curl -fsSL https://just.systems/install.sh | bash -s -- --to /usr/local/bin
 
+      # Posting identity. With the App secrets set, comments and git operations
+      # come from the app (e.g. "ai4c-agent") instead of the generic
+      # "github-actions[bot]". continue-on-error means the step is a no-op when
+      # the secrets are absent, and the workflow falls back to github.token.
+      - name: Generate agent app token
+        id: agent-token
+        continue-on-error: true
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.AI4C_AGENT_APP_ID }}
+          private-key: ${{ secrets.AI4C_AGENT_PRIVATE_KEY }}
+
       - name: Resolve Claude auth
         if: env.HAS_CLAUDE_AUTH == 'true'
         uses: ./.github/actions/resolve-claude-auth
@@ -91,6 +103,7 @@ jobs:
           # exactly one is ever non-empty and the action never has to arbitrate.
           anthropic_api_key: ${{ env.AUTH_MODE == 'api_key' && secrets.ANTHROPIC_API_KEY || '' }}
           claude_code_oauth_token: ${{ env.AUTH_MODE == 'oauth' && secrets.CLAUDE_CODE_OAUTH_TOKEN || '' }}
+          github_token: ${{ steps.agent-token.outputs.token || github.token }}
           additional_permissions: |
             actions: read
           # One updating comment with progress, rather than a silent run.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,7 +155,8 @@ with an `obsolete ` label prefix and a `replaced_by` where one applies.
 
 ## Adding or editing a term
 
-1. Search first — `just find "<text>"` greps IDs, labels, and synonyms. Duplicate labels
+1. Search first — `just find "<text>"` greps IDs, labels, definitions, synonyms, and the
+   EcoSIM variable name and source file. Duplicate labels
    are a hard error, and near-duplicates are the most common review finding.
 2. Allocate an ID with `just next-id <block>`.
 3. Append the row to `src/ontology/bervo-src.csv`, matching the header width exactly.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,8 +99,14 @@ Columns that carry ontology semantics:
 | `Exact Synonyms` / `Related Synonyms` | `A oio:hasExactSynonym` / `hasRelatedSynonym` | `SPLIT=\|` |
 | `has_units`, `qualifiers`, `attributes`, `measured_ins`, `measurement_ofs`, `contexts`, `value_types` | `A`/`AI BERVO:…` | References to other BERVO terms, `SPLIT=\|` |
 
-Remaining columns (`EcoSIM Variable Name`, `File Name`, `Comment from …`, curation-status
-flags) are provenance and curation bookkeeping.
+Remaining columns are provenance and curation bookkeeping. Two of them matter more than
+that sounds: **`EcoSIM Variable Name` and `File Name` are populated on 1,749 of 2,352 terms
+(74%)**, recording the model parameter and source file a term came from. `just find`
+searches both, so a request phrased in model terms (`just find "Eco_NetRad_col"`) resolves
+directly, and a term's EcoSIM source file predicts its `Category` for 32 of the 33 files.
+See the "EcoSIM provenance" section of the `bervo-terms` skill.
+
+`EcoSIM Other Names` is populated on zero rows.
 
 Conventions:
 
@@ -236,7 +242,8 @@ docs/                           # mkdocs sources; docs/assets/data is generated
 
 Task-specific instructions live in `.claude/skills/`:
 
-- **bervo-terms** — adding, editing, and reviewing terms in `bervo-src.csv`
+- **bervo-terms** — adding, editing, and reviewing terms in `bervo-src.csv`, including
+  EcoSIM provenance and cross-references to other ontologies
 - **bervo-build** — building, validating, and releasing
 - **bervo-pr-review** — reviewing a pull request that touches ontology content
 

--- a/README.md
+++ b/README.md
@@ -50,8 +50,14 @@ This repository is set up for AI coding agents (Claude Code, Codex, Copilot, Goo
 - **`.claude/commands/`** provides `/add-term`, `/qc`, and `/pm`.
 - A **PostToolUse hook** validates `bervo-src.csv` automatically after any edit.
 - Mentioning **`@claude`** on an issue or PR triggers a response, and PRs touching
-  ontology content get an automated review. Both need `ANTHROPIC_API_KEY` in the
-  repository secrets and are skipped without it.
+  ontology content or agent instructions get an automated review. Both need
+  `ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN` in the repository secrets, and are
+  skipped without either.
+- The agents post as `github-actions[bot]` by default. To give them their own identity,
+  create a GitHub App, install it on this repository, and add its credentials as the
+  `AI4C_AGENT_APP_ID` and `AI4C_AGENT_PRIVATE_KEY` secrets — the workflows pick them up
+  automatically and fall back to the default token when they are absent. See
+  `docs/agent-identity.md`.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Common tasks are exposed through [`just`](https://just.systems) (`just --list` f
 
 ```bash
 just validate                # structural checks on bervo-src.csv
-just find "soil carbon"      # search labels, definitions, synonyms, EcoSIM names
+just find "soil carbon"      # search IDs, labels, definitions, synonyms, EcoSIM names
 just next-id 0               # next free variable ID
 just show BERVO:0000001      # inspect one term
 just stats                   # term counts by ID block and category

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Common tasks are exposed through [`just`](https://just.systems) (`just --list` f
 
 ```bash
 just validate                # structural checks on bervo-src.csv
-just find "soil carbon"      # search IDs, labels, definitions, synonyms
+just find "soil carbon"      # search labels, definitions, synonyms, EcoSIM names
 just next-id 0               # next free variable ID
 just show BERVO:0000001      # inspect one term
 just stats                   # term counts by ID block and category

--- a/docs/agent-identity.md
+++ b/docs/agent-identity.md
@@ -1,0 +1,72 @@
+# Giving the agents their own identity
+
+By default the Claude-powered workflows post as **`github-actions[bot]`**, the generic
+identity every GitHub Action shares. That makes agent activity indistinguishable from any
+other automation in the repository — CI, page builds, Dependabot.
+
+To have them post as a named identity such as **`ai4c-agent`**, the workflows need a token
+belonging to a GitHub App rather than the default `GITHUB_TOKEN`.
+
+The workflows are already wired for this. Each one runs:
+
+```yaml
+- name: Generate agent app token
+  id: agent-token
+  continue-on-error: true
+  uses: actions/create-github-app-token@v1
+  with:
+    app-id: ${{ secrets.AI4C_AGENT_APP_ID }}
+    private-key: ${{ secrets.AI4C_AGENT_PRIVATE_KEY }}
+```
+
+and then passes `${{ steps.agent-token.outputs.token || github.token }}`. With the secrets
+absent the step is a no-op and everything falls back to the default token, so there is
+nothing to undo if you decide against it.
+
+## Setup
+
+This needs someone with admin rights on the `bioepic-data` organisation; it cannot be done
+from a workflow.
+
+1. **Create the App.** Organisation settings → Developer settings → GitHub Apps → *New
+   GitHub App*. Name it whatever the agents should appear as — the name becomes the comment
+   author, with `[bot]` appended. Set a homepage URL (this repository is fine) and
+   **uncheck Webhook → Active**.
+
+2. **Set repository permissions:**
+
+   | Permission | Access | Needed for |
+   | --- | --- | --- |
+   | Contents | Read and write | Checking out, and committing when asked |
+   | Issues | Read and write | Triage labels and comments |
+   | Pull requests | Read and write | Posting reviews and comments |
+   | Actions | Read | Reading CI results on a PR |
+
+3. **Install it** on `bioepic-data/bervo` (App settings → Install App).
+
+4. **Generate a private key** (App settings → Private keys → *Generate a private key*).
+   A `.pem` file downloads.
+
+5. **Add the secrets:**
+
+   ```bash
+   gh secret set AI4C_AGENT_APP_ID --repo bioepic-data/bervo        # the numeric App ID
+   gh secret set AI4C_AGENT_PRIVATE_KEY --repo bioepic-data/bervo < path/to/key.pem
+   ```
+
+   Paste the `.pem` contents whole, including the `-----BEGIN…` and `-----END…` lines.
+
+The next workflow run posts under the App's name. Nothing else changes — the App token is
+scoped to this repository and expires after each run.
+
+## What this does not change
+
+`bot_id` and `bot_name` on `claude-code-action` control the **git author** on any commit the
+agent makes, not the comment author. They default to `claude[bot]`. If you want commits
+attributed to the App as well, set them to the App's bot user id and `<app-name>[bot]`; the
+id is visible at `https://api.github.com/users/<app-name>%5Bbot%5D`.
+
+## Related
+
+`.github/ai-controllers.json` lists the accounts whose `@claude` mentions the workflows will
+act on. It is unrelated to the posting identity.

--- a/justfile
+++ b/justfile
@@ -80,7 +80,7 @@ stats:
     for name, n in cats.most_common(10):
         print(f"  {n:>5}  {name}")
 
-# Search IDs, labels, definitions, and synonyms. Usage: just find "soil carbon"
+# Search IDs, labels, definitions, synonyms, and EcoSIM names. Usage: just find "soil carbon"
 find query:
     #!/usr/bin/env python3
     import csv

--- a/justfile
+++ b/justfile
@@ -93,11 +93,15 @@ find query:
     watch = [cols[n] for n in ("ID", "Label (description)", "Definition",
                                "Exact Synonyms", "Related Synonyms",
                                "EcoSIM Variable Name", "File Name") if n in cols]
-    ecosim = cols.get("EcoSIM Variable Name")
+    ecosim, fname = cols.get("EcoSIM Variable Name"), cols.get("File Name")
     hits = [r for r in data if any(q in r[i].casefold() for i in watch if i < len(r))]
+    def cell(r, i):
+        return r[i].strip() if i is not None and i < len(r) else ""
     for r in hits[:40]:
-        tag = f"  <{r[ecosim]}>" if ecosim is not None and ecosim < len(r) and r[ecosim].strip() else ""
-        print(f"{r[0]:<20} {r[1]:<45} [{r[2]}]{tag}")
+        # Show both EcoSIM columns: they are searched, so a hit that matches
+        # neither the label nor the definition is otherwise unexplainable.
+        prov = " / ".join(x for x in (cell(r, ecosim), cell(r, fname)) if x)
+        print(f"{r[0]:<20} {r[1]:<45} [{r[2]}]" + (f"  <{prov}>" if prov else ""))
     print(f"\n{len(hits)} match(es)" + (" (showing first 40)" if len(hits) > 40 else ""))
 
 # Next free ID in a block: 0 = variables, 8 = concepts, 9 = grouping classes.

--- a/justfile
+++ b/justfile
@@ -88,11 +88,16 @@ find query:
     rows = list(csv.reader(open("{{template}}", encoding="utf-8")))
     header, data = rows[0], rows[2:]
     cols = {n: i for i, n in enumerate(header)}
+    # EcoSIM provenance is searched too: 74% of terms carry a model variable
+    # name, and a request phrased in model terms should resolve directly.
     watch = [cols[n] for n in ("ID", "Label (description)", "Definition",
-                               "Exact Synonyms", "Related Synonyms") if n in cols]
+                               "Exact Synonyms", "Related Synonyms",
+                               "EcoSIM Variable Name", "File Name") if n in cols]
+    ecosim = cols.get("EcoSIM Variable Name")
     hits = [r for r in data if any(q in r[i].casefold() for i in watch if i < len(r))]
     for r in hits[:40]:
-        print(f"{r[0]:<20} {r[1]:<45} [{r[2]}]")
+        tag = f"  <{r[ecosim]}>" if ecosim is not None and ecosim < len(r) and r[ecosim].strip() else ""
+        print(f"{r[0]:<20} {r[1]:<45} [{r[2]}]{tag}")
     print(f"\n{len(hits)} match(es)" + (" (showing first 40)" if len(hits) > 40 else ""))
 
 # Next free ID in a block: 0 = variables, 8 = concepts, 9 = grouping classes.

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -46,3 +46,4 @@ nav:
           - Continuous Integration: odk-workflows/ContinuousIntegration.md
           - Your ODK Repository Overview: odk-workflows/RepositoryFileStructure.md 
       - Contributing: contributing.md
+      - Agent identity: agent-identity.md


### PR DESCRIPTION
Closes #35.

The last outstanding piece of #35, which asked for agent context on BERVO's relationship to
"models like EcoSIM". Everything else in that issue landed in #39 and #42; EcoSIM was the
gap.

## Why it was a gap

The shipped docs mentioned EcoSIM twice as history and once in a line lumping its columns
into "provenance and curation bookkeeping". The data says otherwise: **`EcoSIM Variable
Name` and `File Name` are populated on 1,749 of 2,352 terms (74%)**.

## What's added

A new **"EcoSIM provenance"** section in the `bervo-terms` skill:

**The source file predicts the category.** 32 of the 33 EcoSIM source files map to one
dominant BERVO `Category` — the strongest placement prior available for a new
EcoSIM-derived term:

| `File Name` | Dominant `Category` | Share |
| --- | --- | --- |
| `SoluteParMod.txt` | Constants for specific chemical reactions | 100% |
| `SoilBGCDataType.txt` | Soil biogeochemistry variable | 98% |
| `SoilWaterDataType.txt` | Soil and water variable | 96% |
| `CanopyDataType.txt` | Canopy variable | 90% |

**The naming conventions.** Suffixes mark what a variable is resolved over — `_col` (361),
`_vr` (304), `_pft` (263), `_brch` (70), `_2D`/`_2DH` (43) — and `trcg_`/`trcs_`/`trcn_`/
`trcSalt_`/`TRChem_`/`DOM_`/`Eco_` group tracers and ecosystem quantities. These are
presented as *observed* conventions to confirm against the definition, not as rules. Only
`_brch` is well evidenced by the data itself (64% of its definitions mention a branch).
`_vr` is **not**: just 7 of 304 labels (2%) contain "vertical", and the union of
vertical/layer/depth/profile across label or definition is 19%. The reading is sound on
inspection, but the table now carries that figure rather than implying the labels say so.
*(Corrected after the automated review caught the original claim.)*

**A duplicate-avoidance note**: two terms differing only by EcoSIM suffix are usually
genuinely distinct — a column aggregate and its vertically resolved counterpart are
different things — but the definitions have to say how, or they become indistinguishable.

## `just find` now searches EcoSIM columns

Writing the section surfaced that guidance I had drafted was simply false:
`just find "Eco_NetRad_col"` returned nothing, because the recipe only searched IDs, labels,
definitions and synonyms.

I fixed the recipe rather than softening the claim — searching by model variable name is
precisely what someone coming from EcoSIM needs. It now also shows the variable name in the
output:

```
$ just find "Eco_NetRad_col"
BERVO:0000001   Ecosystem net radiation   [Biogeochemical flux variable]  <Eco_NetRad_col>

$ just find "CanopyDataType.txt"
149 match(es)
```

Label search is unchanged (`just find "soil carbon"` still returns its 34 matches).

## Also

`EcoSIM Other Names` is populated on **zero** rows; recorded so nobody invents a use for it.

## Verification

```
just validate  →  0 errors, 67 warnings — OK
just test      →  43 passed
```

No ontology content changes — documentation and one `just` recipe.

