### PR TITLE
Stop the review skill flagging every correct content PR

### DIFF
--- a/.claude/rules/generated-artifacts.md
+++ b/.claude/rules/generated-artifacts.md
@@ -31,5 +31,10 @@ Regenerate rather than edit:
 | `site/` | `just docs` |
 | release artefacts (`bervo*.owl/obo/json`) | ODK release pipeline only |
 
-Do not commit regenerated release artefacts alongside a content change unless you
-are deliberately cutting a release.
+Do not commit regenerated *release* artefacts (`bervo*.owl/obo/json`, `site/`)
+alongside a content change unless you are deliberately cutting a release.
+
+`src/ontology/components/bervo-src.owl` is the exception: it is a tracked build
+product, and a content change is expected to commit it regenerated alongside the
+CSV edit. Rebuild it with `just build` rather than editing it, and check the
+resulting diff corresponds to your CSV change.

--- a/.claude/skills/bervo-pr-review/SKILL.md
+++ b/.claude/skills/bervo-pr-review/SKILL.md
@@ -29,8 +29,13 @@ Flag these before reading the content:
 - **A whole-file CSV rewrite.** If `git diff --stat` shows ~2,300 changed rows for a
   few new terms, the file was re-encoded (CRLF → LF, or requoted). Ask for it to be
   redone in place.
-- **Edits to generated files.** Any change under `src/ontology/components/` is a
-  mistake; the content belongs in the CSV.
+- **Hand-edited generated files.** `src/ontology/components/bervo-src.owl` is a tracked
+  build product, and a content PR is *expected* to commit it regenerated alongside the
+  CSV edit — that is not a problem. What is a problem is a component diff that does not
+  correspond to the CSV diff: axioms changed that no CSV cell explains, or a component
+  change with no CSV change at all. That means someone edited the build output by hand,
+  and the next `just build` will silently discard it. Spot-check that each changed axiom
+  traces back to a changed cell.
 
 ## 3. Content review
 


### PR DESCRIPTION
Follow-up to the automated review on #46, which caught a false rule in its own instructions.

## The bug

`.claude/skills/bervo-pr-review/SKILL.md` told the reviewing agent:

> **Edits to generated files.** Any change under `src/ontology/components/` is a mistake;
> the content belongs in the CSV.

Taken literally, that flags **every correct content PR**. `components/bervo-src.owl` is a
tracked build product, and repo practice is to commit it regenerated alongside the CSV edit:

| Commit | CSV | Component |
| --- | --- | --- |
| `8f88255` | ✓ | ✓ |
| `7863d2b` | ✓ | ✓ |
| `527460c` (the PR whose review found this) | ✓ | ✓ |

The reviewer noticed the rule would condemn the very PR it was reviewing, and flagged it
rather than applying it.

## The fix

The rule now distinguishes *hand-editing* the component from *committing a regenerated*
one, and gives the reviewer something actually checkable:

> What is a problem is a component diff that does not correspond to the CSV diff: axioms
> changed that no CSV cell explains, or a component change with no CSV change at all. That
> means someone edited the build output by hand, and the next `just build` will silently
> discard it. Spot-check that each changed axiom traces back to a changed cell.

That is the real failure mode — a hand-edited component looks fine until the next build
throws the edit away.

## Also

`.claude/rules/generated-artifacts.md` ended with "do not commit regenerated release
artefacts alongside a content change", which is correct but left the component's status to
be inferred from a table further up. Now stated explicitly, since that is the case an agent
is most likely to get wrong.

## Why separate from #46

#46 is a content fix for #37. This is an instruction change, and guidance in `.claude/**`
propagates into every later agent run. Keeping them apart per `AGENTS.md`'s one-logical-change
guidance — the same point the reviewer made about #42.

## Verification

```
just validate  →  0 errors, 67 warnings — OK
just test      →  43 passed
```

Documentation only; no ontology content or tooling behaviour changes.
