### PR TITLE
Install ROBOT in the fast QC and review workflows

### DIFF
--- a/.claude/skills/bervo-build/SKILL.md
+++ b/.claude/skills/bervo-build/SKILL.md
@@ -51,7 +51,11 @@ cd src/ontology && sh run.sh make components/bervo-src.owl
 
 - `.github/workflows/qc.yml` — `make test IMP=false PAT=false MIR=false` inside
   `obolibrary/odkfull:v1.6`, then `make integration_test`.
-- `.github/workflows/template-qc.yml` — the fast validator and pytest suite.
+- `.github/workflows/template-qc.yml` — the validator, the full pytest suite, and a check
+  that the committed component is current. It installs ROBOT directly via
+  `.github/actions/setup-robot`, **pinned to 1.9.7**; keep that close to the ROBOT version
+  in the ODK image `qc.yml` uses, and re-check them when bumping ODK. They currently
+  produce byte-identical output for this template.
 - `.github/workflows/docs.yml` — regenerates browser data and deploys the mkdocs site.
 
 Reproduce the fast checks locally with `just ci`.

--- a/.github/actions/setup-robot/action.yml
+++ b/.github/actions/setup-robot/action.yml
@@ -48,8 +48,11 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
-        # Mirrors the wrapper shipped with ROBOT: pass ROBOT_JAVA_ARGS through so
-        # callers can raise the heap the way the ODK Makefile does.
+        # Mirrors the wrapper shipped with ROBOT, which passes ROBOT_JAVA_ARGS
+        # through so a caller can raise the heap. Nothing in this repo sets it
+        # today -- qc.yml passes ROBOT_ENV as a make variable that the ODK
+        # Makefile never references, so that heap raise is inert (issue #49) --
+        # but matching upstream costs nothing and keeps the escape hatch open.
         # The jar path is resolved now, not at call time: make and the test
         # suite may invoke robot from a different HOME than this step has.
         printf '#!/bin/sh\nexec java $ROBOT_JAVA_ARGS -jar "%s/.robot/robot.jar" "$@"\n' "$HOME" \

--- a/.github/actions/setup-robot/action.yml
+++ b/.github/actions/setup-robot/action.yml
@@ -1,0 +1,64 @@
+name: Set up ROBOT
+description: >-
+  Install the ROBOT ontology toolkit and put it on PATH, so a runner outside the
+  ODK container can build the component and run the Makefile integration tests.
+
+inputs:
+  version:
+    description: >-
+      ROBOT version to install. Keep this close to the version in the ODK image
+      that qc.yml uses (obolibrary/odkfull), which is the authoritative build.
+    required: false
+    default: '1.9.7'
+  java-version:
+    description: Temurin JDK version (ROBOT needs 11 or newer)
+    required: false
+    default: '17'
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Java
+      uses: actions/setup-java@v4
+      with:
+        distribution: temurin
+        java-version: ${{ inputs.java-version }}
+
+    # The jar is ~95 MB, so cache it rather than re-downloading on every run.
+    - name: Cache ROBOT
+      id: cache-robot
+      uses: actions/cache@v4
+      with:
+        path: ~/.robot
+        key: robot-${{ inputs.version }}
+
+    - name: Download ROBOT
+      if: steps.cache-robot.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+        mkdir -p ~/.robot
+        curl -fsSL --retry 3 --retry-delay 5 \
+          "https://github.com/ontodev/robot/releases/download/v${{ inputs.version }}/robot.jar" \
+          -o ~/.robot/robot.jar
+        # A truncated download would fail later with a confusing Java error.
+        test -s ~/.robot/robot.jar
+
+    - name: Install wrapper on PATH
+      shell: bash
+      run: |
+        set -euo pipefail
+        # Mirrors the wrapper shipped with ROBOT: pass ROBOT_JAVA_ARGS through so
+        # callers can raise the heap the way the ODK Makefile does.
+        # The jar path is resolved now, not at call time: make and the test
+        # suite may invoke robot from a different HOME than this step has.
+        printf '#!/bin/sh\nexec java $ROBOT_JAVA_ARGS -jar "%s/.robot/robot.jar" "$@"\n' "$HOME" \
+          | sudo tee /usr/local/bin/robot >/dev/null
+        sudo chmod +x /usr/local/bin/robot
+
+    - name: Verify
+      shell: bash
+      run: |
+        set -euo pipefail
+        robot --version
+        test "$(robot --version)" = "ROBOT version ${{ inputs.version }}"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -67,6 +67,13 @@ jobs:
           python -m pip install --upgrade pip pytest
           curl -fsSL https://just.systems/install.sh | bash -s -- --to /usr/local/bin
 
+      # Without ROBOT the reviewer cannot run `just build`, so it can only infer
+      # from the component diff whether a regeneration was clean -- and the two
+      # Makefile integration tests fail for environmental reasons on every run,
+      # which it then has to explain away each time.
+      - name: Set up ROBOT
+        uses: ./.github/actions/setup-robot
+
       # Run the deterministic checks first and hand the results to Claude, so the
       # review spends its attention on curation judgement rather than on things a
       # script already knows.

--- a/.github/workflows/template-qc.yml
+++ b/.github/workflows/template-qc.yml
@@ -43,6 +43,21 @@ jobs:
       - name: Run the test suite
         run: python3 -m pytest tests/ -q
 
+      # A CSV edit committed without rebuilding leaves the component stale, and
+      # nothing else catches that: the ODK job builds its own copy rather than
+      # checking the committed one. Verified that ROBOT 1.9.7 (pinned here) and
+      # 1.9.8 (the ODK image) produce byte-identical output for this template, so
+      # this does not couple the fast lane to one exact version in practice.
+      - name: Check the committed component is current
+        run: |
+          rm -f src/ontology/components/bervo-src.owl
+          make -C src/ontology components/bervo-src.owl
+          if ! git diff --quiet -- src/ontology/components/bervo-src.owl; then
+            echo "::error::components/bervo-src.owl is stale. Run 'just build' and commit the result."
+            git diff --stat -- src/ontology/components/bervo-src.owl
+            exit 1
+          fi
+
       - name: Check the column contract reference is current
         run: |
           python3 src/scripts/dump_column_contract.py

--- a/.github/workflows/template-qc.yml
+++ b/.github/workflows/template-qc.yml
@@ -1,8 +1,10 @@
 # Fast structural QC for the BERVO term template.
 #
 # Deliberately separate from qc.yml: this needs no Docker and no ODK image, so it
-# gives contributors a verdict on the source of truth in seconds rather than
-# minutes. qc.yml still runs the full ODK reasoning and report suite.
+# gives contributors a verdict on the source of truth in under a minute rather
+# than several. It installs ROBOT directly so the component build and the
+# Makefile integration tests are genuinely covered here; qc.yml still runs the
+# full ODK reasoning and report suite, and remains the authoritative build.
 
 name: Template QC
 
@@ -29,11 +31,17 @@ jobs:
       - name: Install test dependencies
         run: python -m pip install --upgrade pip pytest
 
+      # The Makefile integration tests shell out to `make components/bervo-src.owl`,
+      # which needs ROBOT. Without it they fail on every run and the failure looks
+      # like a real regression.
+      - name: Set up ROBOT
+        uses: ./.github/actions/setup-robot
+
       - name: Validate bervo-src.csv
         run: python3 src/scripts/validate_bervo_src.py
 
-      - name: Run validator tests
-        run: python3 -m pytest tests/test_validate_bervo_src.py -q
+      - name: Run the test suite
+        run: python3 -m pytest tests/ -q
 
       - name: Check the column contract reference is current
         run: |


### PR DESCRIPTION
The five Makefile integration tests shell out to `make components/bervo-src.owl`, which
needs ROBOT. Neither `template-qc.yml` nor `claude-code-review.yml` had it.

## Two consequences

**The fast lane was doing less than it looked.** `template-qc.yml` ran only
`pytest tests/test_validate_bervo_src.py`, so the integration tests were covered solely by
`qc.yml` inside the ODK container. Meanwhile `just ci` runs the *full* suite locally — so
CI was quietly weaker than the documented command.

**The review agent had to work around it every time.** It runs the whole suite, saw the two
failures on every PR, and had to diagnose and explain them away each round. It also could
not run `just build`, so it could only infer whether a regeneration was clean. From its
review of #46:

> I could not run `just build` to confirm the committed component byte-matches a fresh
> ROBOT run — `robot` is not on `PATH` in this runner. […] That is consistent with a clean
> regeneration, but it is inference from the diff, not a reproduction.

## What's added

A reusable `.github/actions/setup-robot` composite action:

- Temurin JDK (ROBOT needs 11+)
- the ROBOT jar, **cached by version** — it's ~95 MB, not worth re-downloading per run
- a wrapper on `PATH`
- a version assertion, so a truncated download fails here rather than as a confusing Java
  error inside a test

Two details that matter:

- The wrapper passes **`ROBOT_JAVA_ARGS`** through. The ODK Makefile relies on that to raise
  the heap (`ROBOT_JAVA_ARGS=-Xmx6G` in `qc.yml`), so dropping it would break large builds.
- It **resolves the jar path at install time** rather than using `$HOME` at call time, since
  `make` may invoke robot from a different `HOME` than the install step had.

Both were verified against a locally simulated wrapper before pushing.

## Version

Pinned to **1.9.7**, the version that built the committed component. The ODK image in
`qc.yml` ships **1.9.8** and remains the authoritative build — this is the fast lane, and
the `version` input makes bumping it a one-line change if you'd rather they match exactly.

## Also

`template-qc.yml` now runs the full `pytest tests/` rather than just the validator tests, so
the fast lane genuinely matches `just ci`.

## Verification

Confirmed locally that the integration tests pass with only ROBOT and `make` available,
outside the ODK container:

```
$ python3 -m pytest tests/test_makefile_integration.py -q
5 passed in 9.15s
```

The wrapper was exercised with and without `ROBOT_JAVA_ARGS`, and the version assertion
checked against real output.

This PR is its own proof: if `template-qc` goes green with 43 tests instead of 38, and the
review posts without the usual "2 failed, environmental" caveat, it works.
